### PR TITLE
Corrected unrecognized coding system utf_8 to utf-8.

### DIFF
--- a/dviasm.py
+++ b/dviasm.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python2.7
-# -*- coding: utf_8 -*-
+# -*- coding: utf-8 -*-
 #
 # This is DVIasm, a DVI utility for editing DVI files directly.
 #


### PR DESCRIPTION
Visiting this file in Emacs produces an error because it does not recognize the symbol `utf_8` as a coding system.  The correct identifier is `utf-8`.
