### PR TITLE
Fix font size unit

### DIFF
--- a/dviasm.py
+++ b/dviasm.py
@@ -904,8 +904,8 @@ class DVI(object):
     for e in sorted(self.font_def.keys()):
       fp.write("fntdef: %s" % self.font_def[e]['name'])
       if self.font_def[e]['design_size'] != self.font_def[e]['scaled_size']:
-        fp.write(" (%s) " % self.by_pt_conv(self.font_def[e]['design_size']))
-      fp.write(" at %s\n" % self.by_pt_conv(self.font_def[e]['scaled_size']))
+        fp.write(" (%s) " % self.byconv(self.font_def[e]['design_size']))
+      fp.write(" at %s\n" % self.byconv(self.font_def[e]['scaled_size']))
     # DumpPages
     for page in self.pages:
       fp.write("\n[page" + (" %d"*10 % tuple(page['count'])) + "]\n")
@@ -941,8 +941,8 @@ class DVI(object):
           if IsFontChanged(f, z):
             fp.write("fnt: %s " % cur_font)
             if self.font_def[cmd[1]]['design_size'] != self.font_def[cmd[1]]['scaled_size']:
-              fp.write("(%s) " % self.by_pt_conv(self.font_def[cmd[1]]['design_size']))
-            fp.write("at %s\n" % self.by_pt_conv(cur_ssize))
+              fp.write("(%s) " % self.byconv(self.font_def[cmd[1]]['design_size']))
+            fp.write("at %s\n" % self.byconv(cur_ssize))
         elif cmd[0] == GLYPHS:
           fp.write("setglyphs: %s\n" % self.DumpGlyphs(cmd[1][0], cmd[1][1]))
         elif cmd[0] == TEXT_GLYPHS:


### PR DESCRIPTION
dviasm always output a text file
with a font size description in pt unit
regardless of the command line option unit specification.

This commit makes dviasm outputs the font size in the specified unit.